### PR TITLE
Fiks for Safari-bug når brukeren trykker "Enter"

### DIFF
--- a/country-portal.js
+++ b/country-portal.js
@@ -5,17 +5,3 @@ function searchWP(languageCode) {
 window.onload = function() {
     document.getElementById('searchString').focus();
 };
-
-window.addEventListener("keydown", function (event) {
-    if (event.defaultPrevented) {
-        return;
-    }
-
-    if (event.key === 'Enter') {
-        searchWP('no');
-    } else {
-        return;
-    }
-
-    event.preventDefault();
-}, true);

--- a/index.html
+++ b/index.html
@@ -37,7 +37,8 @@
             </div>
 
             <div class="container text-center">
-                <form role="form">
+                <form role="form" action="javascript:searchWP('no');">
+
                     <div class="form-group">
                             <input type="search" class="form-control" id="searchString">
                             <button type="button" class="btn btn-primary" onclick="searchWP('no')" lang="nb">S&oslash;k p&aring; bokm&aring;l</button>


### PR DESCRIPTION
I Safari tømmes bare søkeboksen når brukeren trykker enter; legger nå på en form action som slår inn. Dette fikser https://github.com/Laaknor/wikipediano/issues/4